### PR TITLE
Notification to use Orbit Fox instead of Llorix One Companion plugin updated.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -187,10 +187,10 @@ if ( ! function_exists( 'llorix_one_lite_setup' ) ) :
 
 			$config_customizer = array(
 				'recommended_plugins'       => array(
-					'llorix-one-companion' => array(
+					'themeisle-companion' => array(
 						'recommended' => true,
 						'description' => /* translators: %1$s is the name for the theme */
-							sprintf( esc_html__( 'If you want to take full advantage of the options this theme has to offer, please install and activate %s', 'llorix-one-lite' ), sprintf( '<strong>%s</strong>', 'Llorix One Companion' ) ),
+							sprintf( esc_html__( 'If you want to take full advantage of the options this theme has to offer, please install and activate %s', 'llorix-one-lite' ), sprintf( '<strong>%s</strong>', 'Orbit Fox' ) ),
 					),
 				),
 				'recommended_actions'       => array(),

--- a/functions.php
+++ b/functions.php
@@ -437,8 +437,8 @@ function llorix_one_lite_register_required_plugins() {
 
 	$plugins = array(
 		array(
-			'name'     => 'Llorix One Companion',
-			'slug'     => 'llorix-one-companion',
+			'name'     => 'Orbit Fox',
+			'slug'     => 'themeisle-companion',
 			'required' => false,
 		),
 	);


### PR DESCRIPTION
This is related to the integration of Llorix One Companion plugin into Orbit Fox.
https://github.com/Codeinwp/themeisle-companion/pull/225

Notification updated in Dashboard and Customizer.